### PR TITLE
Use protocol agnostic URL to load jQuery

### DIFF
--- a/app/views/pages/index.liquid
+++ b/app/views/pages/index.liquid
@@ -62,7 +62,7 @@ editable_elements:
   {% endblock %}
 
   <!-- javascripts -->
-  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
   {{ 'semantic-1.9.0.js' | javascript_tag }}
   {{ 'attache.js' | javascript_tag }}
   {{ section_javascript | javascript_tag }}


### PR DESCRIPTION
Now that the website uses `HTTPS`, ensure that `jQuery` can be loaded securely. Use `//` to allow the current scheme to define which protocol to use.